### PR TITLE
Update AdventurePlayer.java

### DIFF
--- a/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
+++ b/forge-gui-mobile/src/forge/adventure/player/AdventurePlayer.java
@@ -150,6 +150,8 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
         this.difficultyData.enemyLifeFactor = difficultyData.enemyLifeFactor;
         this.difficultyData.sellFactor = difficultyData.sellFactor;
         this.difficultyData.shardSellRatio = difficultyData.shardSellRatio;
+        this.difficultyData.goldLoss = difficultyData.goldLoss;
+        this.difficultyData.lifeLoss = difficultyData.lifeLoss;
 
         gold = difficultyData.staringMoney;
         name = n;
@@ -187,6 +189,8 @@ public class AdventurePlayer implements Serializable, SaveFileContent {
         this.difficultyData.enemyLifeFactor = diff.enemyLifeFactor;
         this.difficultyData.sellFactor = diff.sellFactor;
         this.difficultyData.shardSellRatio = diff.shardSellRatio;
+        this.difficultyData.goldLoss = diff.goldLoss;
+        this.difficultyData.lifeLoss = diff.lifeLoss;
         resetToMaxLife();
     }
 


### PR DESCRIPTION
Both goldLoss and lifeLoss where not being set on creation + update difficulty. So regardless of difficulty chosen, on defeat the default value on the difficultyData class for the properties (0.2f) was being used